### PR TITLE
Add i2c and string support

### DIFF
--- a/lib/firmata/protocol/mixin.ex
+++ b/lib/firmata/protocol/mixin.ex
@@ -41,10 +41,20 @@ defmodule Firmata.Protocol.Mixin do
       # internal: fixnum byte sysex command for firmware query and response
       @firmware_query 0x79
 
-      defp to_hex(<<byte>>) do
+      @i2c_config 0x78
+
+      @i2c_request 0x76
+
+      @i2c_response 0x77
+
+      @i2c_mode %{write: 00, read: 10}
+
+      @string_data 0x71
+
+
+      def to_hex(<<byte>>) do
         "0x"<>Integer.to_string(byte, 16)
       end
     end
   end
 end
-

--- a/lib/firmata/protocol/sysex.ex
+++ b/lib/firmata/protocol/sysex.ex
@@ -17,8 +17,17 @@ defmodule Firmata.Protocol.Sysex do
     {:analog_mapping_response, analog_mapping_response(sysex)}
   end
 
-  def parse(bad_byte, _sysex) do
-    IO.puts "Unrecognized sysex command #{to_hex(bad_byte)}"
+  def parse(@i2c_response, sysex) do
+    {:i2c_response, binary(sysex)}
+  end
+
+  def parse(@string_data, sysex) do
+    {:string_data, binary(sysex)}
+  end
+
+  def parse(bad_byte, sysex) do
+    IO.puts bad_byte
+    IO.puts sysex
   end
 
   def firmware_query(sysex) do
@@ -75,5 +84,8 @@ defmodule Firmata.Protocol.Sysex do
   def analog_mapping_response(sysex) do
     sysex |> Enum.map(&analog_mapping_response/1)
   end
-end
 
+  def binary(sysex) do
+    [value: sysex]
+  end
+end


### PR DESCRIPTION
Allow analog reporting to be handled by an individual process per channel/pin.
Update README with up-to-date examples and links to example application